### PR TITLE
Added endpoint to ask seeding to stop

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -44,5 +44,34 @@ export default class App extends EventEmitter {
                 return { status: 'ok' }
             }
         })
+
+        this.server.route({
+            method: 'DELETE',
+            url: '/seeding/hypercore/:key',
+            schema: {
+                params: {
+                    type: 'object',
+                    required: ['key'],
+                    properties: {
+                        key: {
+                            type: 'string',
+                            pattern: '^[a-fA-F0-9]{64}$'
+                        }
+                    }
+                },
+                response: {
+                    200: {
+                        type: 'object',
+                        properties: {
+                            status: { type: 'string' }
+                        }
+                    }
+                }
+            },
+            handler: async (request, reply) => {
+                this.emit('deleteKey', { key: Buffer.from(request.params.key, 'hex') })
+                return { status: 'ok' }
+            }
+        })
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,4 +8,5 @@ await seeder.start()
 // Create the HTTP server app
 const app = new App()
 app.on('keyDiscovered', async (data) => seeder.registerHypercore(data.key))
+app.on('deleteKey', async (data) => seeder.removeHypercore(data.key))
 await app.start()

--- a/src/test-client.js
+++ b/src/test-client.js
@@ -21,6 +21,17 @@ console.log("PublicKey", core.key.toString('hex'))
 
 // Create a hyperswarm and advertise the core to any interested peers
 const swarm = new Hyperswarm()
-swarm.on('connection', (conn, peerInfo) => store.replicate(conn))
+swarm.on('connection', (conn, peerInfo) => {
+    console.log('Seen connection from peer')
+    store.replicate(conn)
+})
 
 swarm.join(core.discoveryKey)
+
+// a second core
+const other = store.get({ name: config.get('testClient.coreName') + 'other' })
+await other.ready()
+await other.append(['hello', 'world'])
+swarm.join(other.discoveryKey)
+console.log("Other DiscoveryKey", other.discoveryKey.toString('hex'))
+console.log("Other PublicKey", other.key.toString('hex'))


### PR DESCRIPTION
When called, the hypercore will be dropped from the seeding set and connections to peers dropped.

Also, when adding a core that already is being tracked, we now update the last seen time for it, essentially keeping the seeding alive for longer. If the app requests it’s core be seeded each time it is opened, this should keep them alive, even if there are not changes to the content.