### PR TITLE
upgrade hypercore to ^10.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -606,12 +606,12 @@
         "xache": "^1.1.0"
       }
     },
-    "node_modules/crc32-universal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crc32-universal/-/crc32-universal-1.0.1.tgz",
-      "integrity": "sha512-s5aeEG79zDRscFoDVtcsWNNSLrpRk9PVINTGIBtRW/wGWYw1tJiSrpNo7yTxokJcbg6SvYgy/NHlMxlyuBL1pg==",
+    "node_modules/crc-universal": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/crc-universal/-/crc-universal-1.0.2.tgz",
+      "integrity": "sha512-RrQ/8bT3WKNsGQuHWV3wf3Y0SUJTa8GADrkrQ1gsDljJLs8h/ENJRFUkL3z1TRWas80gv3Kdo6z1IPYyVJ/sxQ==",
       "dependencies": {
-        "node-gyp-build": "^4.2.3"
+        "node-gyp-build": "^4.5.0"
       }
     },
     "node_modules/debug": {
@@ -1032,22 +1032,22 @@
       }
     },
     "node_modules/hypercore": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-10.2.1.tgz",
-      "integrity": "sha512-+nf1e7FXLXpYlENk8CK/abjg5DPhXQEXIiYtzNQTH8ah9+FsFjhSN8+FgvFTOF8VxQQm/xd+tqdnwUDykaHwnw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-10.5.0.tgz",
+      "integrity": "sha512-FIEaB7AWbomXdBQWLhlky4RbPXZmCPttHjuaKKD/UTtk6Mt22o3C2xOF6rSSdolaTC9Aq8y+pzZ056ntY/ooFQ==",
       "dependencies": {
         "@hyperswarm/secret-stream": "^6.0.0",
         "b4a": "^1.1.0",
         "big-sparse-array": "^1.0.2",
-        "bits-to-bytes": "^1.3.0",
         "compact-encoding": "^2.11.0",
-        "crc32-universal": "^1.0.1",
+        "crc-universal": "^1.0.2",
         "events": "^3.3.0",
         "flat-tree": "^1.9.0",
         "hypercore-crypto": "^3.2.1",
         "is-options": "^1.0.1",
         "protomux": "^3.4.0",
-        "random-access-file": "^3.2.2",
+        "quickbit-universal": "^2.0.3",
+        "random-access-file": "^4.0.0",
         "random-array-iterator": "^1.0.0",
         "safety-catch": "^1.0.1",
         "sodium-universal": "^3.0.4",
@@ -1650,15 +1650,34 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
-    "node_modules/random-access-file": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-3.2.2.tgz",
-      "integrity": "sha512-lscY8hUUYqh5LFJpbOH+8st31LtH9k/TAxngjKgc5Kj9bdLpqdeyXTzfvPNNChgNbCrC9mZabOn0E+FCueC7cA==",
+    "node_modules/quickbit-universal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/quickbit-universal/-/quickbit-universal-2.0.3.tgz",
+      "integrity": "sha512-cdyTFj+fa7iGHMNM/gMXJscTiRZt6yIhRx8fYIFT+xaxXPB3dmSy1mY9BkDf21ONqb6PZMggm5E1Huj+72+bjQ==",
       "dependencies": {
-        "random-access-storage": "^2.2.0"
+        "b4a": "^1.6.0",
+        "node-gyp-build": "^4.5.0",
+        "simdle-universal": "^1.1.0"
+      }
+    },
+    "node_modules/random-access-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-4.0.0.tgz",
+      "integrity": "sha512-9nk4xujIoF1bGVxd6XiM/3cnJevNYLAjv9nPmJXbCn/3fxXBr9jb9IodIDJvtiTKFwVzlwGzGGqM+zVbRw6Yaw==",
+      "dependencies": {
+        "random-access-storage": "^3.0.0"
       },
       "optionalDependencies": {
         "fs-native-extensions": "^1.1.0"
+      }
+    },
+    "node_modules/random-access-file/node_modules/random-access-storage": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-3.0.0.tgz",
+      "integrity": "sha512-f9KeHUMhrqj0hE2d4HbUXk/Cd5vElaVzdA0PuqPTlnxsG3dDvwQaMg8POT5tWK6UxJ80zAONZpHgLPMnnff1RA==",
+      "dependencies": {
+        "events": "^3.3.0",
+        "queue-tick": "^1.0.0"
       }
     },
     "node_modules/random-access-memory": {
@@ -1912,6 +1931,15 @@
       "integrity": "sha512-abgDPg1106vuZZOvw7cFwdCABddfJRz5akcCcchzTbhyhYnsG31y4AlZEgp315T7W3nQq5P4xeOm186ZiPVFzw==",
       "dependencies": {
         "varint": "~5.0.0"
+      }
+    },
+    "node_modules/simdle-universal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/simdle-universal/-/simdle-universal-1.1.0.tgz",
+      "integrity": "sha512-ZH+N1FHGksLWcNgpuaVaX2pI86Zzu58Y5S1mNXd2HuMId75eRsrtpAmCG1RZJXclViUiACVsLA3LD3TQVpha5Q==",
+      "dependencies": {
+        "b4a": "^1.6.0",
+        "node-gyp-build": "^4.2.3"
       }
     },
     "node_modules/sinon": {
@@ -2822,12 +2850,12 @@
         "xache": "^1.1.0"
       }
     },
-    "crc32-universal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crc32-universal/-/crc32-universal-1.0.1.tgz",
-      "integrity": "sha512-s5aeEG79zDRscFoDVtcsWNNSLrpRk9PVINTGIBtRW/wGWYw1tJiSrpNo7yTxokJcbg6SvYgy/NHlMxlyuBL1pg==",
+    "crc-universal": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/crc-universal/-/crc-universal-1.0.2.tgz",
+      "integrity": "sha512-RrQ/8bT3WKNsGQuHWV3wf3Y0SUJTa8GADrkrQ1gsDljJLs8h/ENJRFUkL3z1TRWas80gv3Kdo6z1IPYyVJ/sxQ==",
       "requires": {
-        "node-gyp-build": "^4.2.3"
+        "node-gyp-build": "^4.5.0"
       }
     },
     "debug": {
@@ -3167,22 +3195,22 @@
       }
     },
     "hypercore": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-10.2.1.tgz",
-      "integrity": "sha512-+nf1e7FXLXpYlENk8CK/abjg5DPhXQEXIiYtzNQTH8ah9+FsFjhSN8+FgvFTOF8VxQQm/xd+tqdnwUDykaHwnw==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-10.5.0.tgz",
+      "integrity": "sha512-FIEaB7AWbomXdBQWLhlky4RbPXZmCPttHjuaKKD/UTtk6Mt22o3C2xOF6rSSdolaTC9Aq8y+pzZ056ntY/ooFQ==",
       "requires": {
         "@hyperswarm/secret-stream": "^6.0.0",
         "b4a": "^1.1.0",
         "big-sparse-array": "^1.0.2",
-        "bits-to-bytes": "^1.3.0",
         "compact-encoding": "^2.11.0",
-        "crc32-universal": "^1.0.1",
+        "crc-universal": "^1.0.2",
         "events": "^3.3.0",
         "flat-tree": "^1.9.0",
         "hypercore-crypto": "^3.2.1",
         "is-options": "^1.0.1",
         "protomux": "^3.4.0",
-        "random-access-file": "^3.2.2",
+        "quickbit-universal": "^2.0.3",
+        "random-access-file": "^4.0.0",
         "random-array-iterator": "^1.0.0",
         "safety-catch": "^1.0.1",
         "sodium-universal": "^3.0.4",
@@ -3672,13 +3700,34 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
+    "quickbit-universal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/quickbit-universal/-/quickbit-universal-2.0.3.tgz",
+      "integrity": "sha512-cdyTFj+fa7iGHMNM/gMXJscTiRZt6yIhRx8fYIFT+xaxXPB3dmSy1mY9BkDf21ONqb6PZMggm5E1Huj+72+bjQ==",
+      "requires": {
+        "b4a": "^1.6.0",
+        "node-gyp-build": "^4.5.0",
+        "simdle-universal": "^1.1.0"
+      }
+    },
     "random-access-file": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-3.2.2.tgz",
-      "integrity": "sha512-lscY8hUUYqh5LFJpbOH+8st31LtH9k/TAxngjKgc5Kj9bdLpqdeyXTzfvPNNChgNbCrC9mZabOn0E+FCueC7cA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-4.0.0.tgz",
+      "integrity": "sha512-9nk4xujIoF1bGVxd6XiM/3cnJevNYLAjv9nPmJXbCn/3fxXBr9jb9IodIDJvtiTKFwVzlwGzGGqM+zVbRw6Yaw==",
       "requires": {
         "fs-native-extensions": "^1.1.0",
-        "random-access-storage": "^2.2.0"
+        "random-access-storage": "^3.0.0"
+      },
+      "dependencies": {
+        "random-access-storage": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-3.0.0.tgz",
+          "integrity": "sha512-f9KeHUMhrqj0hE2d4HbUXk/Cd5vElaVzdA0PuqPTlnxsG3dDvwQaMg8POT5tWK6UxJ80zAONZpHgLPMnnff1RA==",
+          "requires": {
+            "events": "^3.3.0",
+            "queue-tick": "^1.0.0"
+          }
+        }
       }
     },
     "random-access-memory": {
@@ -3881,6 +3930,15 @@
       "integrity": "sha512-abgDPg1106vuZZOvw7cFwdCABddfJRz5akcCcchzTbhyhYnsG31y4AlZEgp315T7W3nQq5P4xeOm186ZiPVFzw==",
       "requires": {
         "varint": "~5.0.0"
+      }
+    },
+    "simdle-universal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/simdle-universal/-/simdle-universal-1.1.0.tgz",
+      "integrity": "sha512-ZH+N1FHGksLWcNgpuaVaX2pI86Zzu58Y5S1mNXd2HuMId75eRsrtpAmCG1RZJXclViUiACVsLA3LD3TQVpha5Q==",
+      "requires": {
+        "b4a": "^1.6.0",
+        "node-gyp-build": "^4.2.3"
       }
     },
     "sinon": {


### PR DESCRIPTION
I have been testing my simple seeders (fully announcing all topics) for 24 hours with the new hypercore (not throwing errors on fork detection).

Seems to be much more stable around ~1GB, which is great. Still testing though if it effectively working (seeding) data correctly.

Still takes 24 minutes to announce everything though, and I suspect it aggressively rate-limit and backlog requests, and fixing that would need changing Hyperswarm itself, or building our own solution with our own config.

Also, we might benefit from Multithreading, by announcing 1/8th of the topics per each CPU core, the only issue here would be avoiding the Corestore lock file issue (by passing a random Primary key so it doesn't depend on the primarykey file maybe)/