### PR TITLE
feat: add hyperswarm-cluster to test it in parallel with seeder topic

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@fastify/websocket": "^7.1.2",
     "@hyperswarm/testnet": "^3.1.1",
+    "@synonymdev/hyperswarm-cluster": "github:Nazeh/hyperswarm-cluster",
     "@synonymdev/slashtags-rpc": "^1.0.0-alpha.1",
     "@synonymdev/slashtags-sdk": "^1.0.0-alpha.18",
     "compact-encoding": "^2.11.0",


### PR DESCRIPTION
As it says on the tin, this PR maintains the seeder topic but also announces _all_ topics (in ~10 minutes on 8 cores, even less if we optimize and ignore empty cores, but this PR announces all).

Then we can test by disabling the seeder topic in the playground and Bitkit (I did and connections are established but not all data is on my device).